### PR TITLE
Fix Node 18 DEP0162 deprecation: Stringify sprites when writing to file

### DIFF
--- a/src/iconoclash.js
+++ b/src/iconoclash.js
@@ -266,7 +266,7 @@
 
 		// write one svg sprite, by default
 		if( !config.writeIndividualFiles ){
-			fs.writeFileSync(this.output + config.iconsvg, sprites);
+			fs.writeFileSync(this.output + config.iconsvg, sprites.toString());
 		}
 		// or if not, write out individual files by teasing them out of the sprite and making new ones
 		// this could be more efficient I'm sure. But the approach is helpful because having them all in the sprite to start helps in exposing shared props


### PR DESCRIPTION
The sprites var is an object (albeit w/ a `toString` method).
In Node 18, calling `writeFileSync` w/ an object like this was deprecated:

```
(node:52408) [DEP0162] DeprecationWarning: Implicit coercion of objects with own toString
```

In Node 20+ it is an error.

This PR allows the code to be run w/ Node 20+ by calling `toString` on that object when writing to file.